### PR TITLE
docs: add native app porting plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,13 @@
 5. **Future Enhancements**
    - Ensure operation when browser minimized or closed
    - Data export, advanced analytics, and platform-specific integrations
+
+## Detailed Action Plan
+
+Detailed documentation for each step is available in `/docs`:
+
+- [Core Timer](docs/core-timer.md)
+- [Background Execution](docs/background-execution.md)
+- [Activity Monitoring and Focus Metric](docs/activity-monitoring.md)
+- [Visualization](docs/visualization.md)
+- [Future Enhancements](docs/future-enhancements.md)

--- a/docs/activity-monitoring.md
+++ b/docs/activity-monitoring.md
@@ -1,0 +1,22 @@
+# Activity Monitoring and Focus Metric
+
+[Back to overview](../AGENTS.md)
+
+## Objectives
+- Capture keyboard and mouse events to gauge activity.
+- Compute "Focus Metric" combining activity frequency and timer status.
+
+## Windows: WPF / WinUI 3
+- Hook global input using `SetWindowsHookEx` or `RawInput`.
+- Record timestamps of events in background service.
+- Aggregate metrics per Pomodoro session.
+
+## Cross-platform: React Native
+- Use libraries like `react-native-global-props` or native modules for input hooks (Android only; limited on iOS).
+- Capture foreground interaction events as fallback.
+- Upload activity samples to JS layer for metric calculations.
+
+## Tasks
+1. Design data structure for storing input events.
+2. Create focus metric algorithm (e.g., events per minute).
+3. Visualize metric in real time and persist historical data.

--- a/docs/background-execution.md
+++ b/docs/background-execution.md
@@ -1,0 +1,22 @@
+# Background Execution
+
+[Back to overview](../AGENTS.md)
+
+## Objectives
+- Ensure timer runs when app minimized or unfocused.
+- Provide user feedback via notifications or tray icon.
+
+## Windows: WPF / WinUI 3
+- Implement tray application using `NotifyIcon`.
+- Use background tasks or services to keep timer running.
+- Handle system suspend/resume events.
+
+## Cross-platform: React Native
+- Use `react-native-background-fetch` or `react-native-background-timer`.
+- Configure headless JS tasks for Android; background fetch API for iOS.
+- Display persistent notifications to indicate active timer.
+
+## Tasks
+1. Prototype background timer execution on each platform.
+2. Validate battery and OS policies for long-running tasks.
+3. Integrate notification controls for start/pause/stop.

--- a/docs/core-timer.md
+++ b/docs/core-timer.md
@@ -1,0 +1,23 @@
+# Core Timer
+
+[Back to overview](../AGENTS.md)
+
+## Objectives
+- Provide configurable Pomodoro and break durations.
+- Persist settings locally on device.
+- Maintain accurate timer state across app restarts.
+
+## Windows: WPF / WinUI 3
+- Use `DispatcherTimer` or `ThreadPoolTimer` for high-resolution timing.
+- Store durations and state using `ApplicationData` or local JSON file.
+- Integrate Windows toast notifications for session transitions.
+
+## Cross-platform: React Native
+- Implement timer with `setInterval` wrapped in native modules for precision.
+- Store settings via `AsyncStorage`.
+- Use `react-native-push-notification` for alerts on iOS/Android.
+
+## Tasks
+1. Define shared configuration schema.
+2. Build timer service module encapsulating start/pause/reset logic.
+3. Expose settings UI and persistence layer.

--- a/docs/future-enhancements.md
+++ b/docs/future-enhancements.md
@@ -1,0 +1,19 @@
+# Future Enhancements
+
+[Back to overview](../AGENTS.md)
+
+## Goals
+- Ensure operation even when browser closed (web fallback).
+- Provide data export and advanced analytics.
+- Support platform-specific integrations.
+
+## Ideas
+- Implement web worker or service worker enhancements for web.
+- Offer CSV/JSON export for sessions.
+- Integrate with OS-specific features like Focus Assist (Windows) or HealthKit (iOS).
+- Explore syncing across devices via cloud storage.
+
+## Tasks
+1. Research platform APIs for focus modes and health integrations.
+2. Design export formats and user flows.
+3. Evaluate cross-device synchronization strategies.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,22 @@
+# Visualization
+
+[Back to overview](../AGENTS.md)
+
+## Objectives
+- Provide real-time status, graphs, and statistics.
+- Display historical data across sessions.
+
+## Windows: WPF / WinUI 3
+- Use `Graph` or `Chart` controls for timeline views.
+- Bind timer and activity data via MVVM pattern.
+- Implement data persistence with `SQLite` or local file.
+
+## Cross-platform: React Native
+- Render charts using libraries such as `victory-native` or `react-native-svg`.
+- Leverage Redux or Context for state management.
+- Store history with `SQLite` (via `react-native-sqlite-storage`) or local files.
+
+## Tasks
+1. Define data models for sessions and metrics.
+2. Build components for real-time progress and summaries.
+3. Implement export function for session history.


### PR DESCRIPTION
## Summary
- add detailed docs outlining plan to port the web timer to native platforms
- index documentation from `AGENTS.md`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80dbae6d48332bbe539865b4dc382