### PR TITLE
docs: add native porting plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,11 @@
 5. **Future Enhancements**
    - Ensure operation when browser minimized or closed
    - Data export, advanced analytics, and platform-specific integrations
+
+## Documentation Index
+- [Framework Selection](docs/framework-selection.md)
+- [Core Timer](docs/core-timer.md)
+- [Background Execution](docs/background-execution.md)
+- [Activity Monitoring and Focus Metric](docs/activity-monitoring.md)
+- [Visualization](docs/visualization.md)
+- [Future Enhancements](docs/future-enhancements.md)

--- a/docs/activity-monitoring.md
+++ b/docs/activity-monitoring.md
@@ -1,0 +1,17 @@
+# Activity Monitoring and Focus Metric
+
+See the overarching [AGENTS plan](../AGENTS.md). This document covers capturing user activity and deriving a focus metric.
+
+## Objectives
+- Capture keyboard and mouse events.
+- Combine activity frequency with timer status to compute a focus score.
+
+## Action Steps
+1. Hook global keyboard and mouse listeners.
+2. Record events alongside timer phases.
+3. Calculate a weighted metric representing focus during each session.
+4. Store historical metrics for analysis.
+
+## Challenges
+- Respecting user privacy and OS security restrictions.
+- Normalizing activity levels across different work styles.

--- a/docs/background-execution.md
+++ b/docs/background-execution.md
@@ -1,0 +1,17 @@
+# Background Execution
+
+Refer to [AGENTS.md](../AGENTS.md) for the high‑level plan. This document details how the timer continues running when the app is minimized or unfocused.
+
+## Objectives
+- Support background services and notifications.
+- Maintain timer progress without UI focus.
+
+## Action Steps
+1. **Windows:** Implement a tray application or Windows background task that keeps the timer active.
+2. **React Native:** Integrate `react-native-background-fetch` or similar library to schedule periodic tasks.
+3. Use local notifications to alert users when sessions end.
+4. Persist session state to recover from process termination.
+
+## Challenges
+- Platform limitations on background execution frequency.
+- Balancing power consumption with timely updates.

--- a/docs/core-timer.md
+++ b/docs/core-timer.md
@@ -1,0 +1,18 @@
+# Core Timer
+
+Part of the [AGENTS plan](../AGENTS.md), this document outlines how to implement the Pomodoro and break timers natively.
+
+## Objectives
+- Store configurable Pomodoro and break durations locally.
+- Provide start, pause, and reset controls.
+- Persist timer state so sessions survive app restarts.
+
+## Action Steps
+1. Define timer models and persistence (local storage or SQLite).
+2. Implement a foreground timer loop with notification hooks.
+3. Expose timer state through a view‑model or context for UI components.
+4. Add unit tests for timing accuracy and state transitions.
+
+## Challenges
+- Ensuring accuracy across sleep or background states.
+- Handling user‑initiated changes mid‑session without losing progress.

--- a/docs/framework-selection.md
+++ b/docs/framework-selection.md
@@ -1,0 +1,18 @@
+# Framework Selection
+
+This document supports the [AGENTS plan](../AGENTS.md) by detailing the framework options for porting the Pomodoro timer to a native application.
+
+## Windows First: WPF / WinUI 3 (.NET)
+- **Rationale:** Provides direct access to Win32 and Windows Runtime APIs.
+- **Benefits:** Small bundle sizes and the ability to run background services or tray applications.
+- **Considerations:** Requires C#/.NET expertise and targets Windows only.
+
+## Cross‑Platform: React Native
+- **Rationale:** Enables iOS, Android, web, and desktop support with one JavaScript/TypeScript codebase.
+- **Benefits:** Reuses existing React skills and has community packages like `react-native-background-fetch` for background work.
+- **Considerations:** Slightly larger bundle size and reliance on third‑party packages for some native features.
+
+## Decision Points
+1. Start with Windows using WPF/WinUI 3 to quickly deliver a fully native desktop experience.
+2. Evaluate React Native once Windows functionality is stable to expand to other platforms.
+3. Keep shared business logic modular to ease future cross‑platform migrations.

--- a/docs/future-enhancements.md
+++ b/docs/future-enhancements.md
@@ -1,0 +1,18 @@
+# Future Enhancements
+
+Aligned with the [AGENTS plan](../AGENTS.md), this document captures potential future improvements once the core app is stable.
+
+## Ideas
+- Keep the timer running when the browser or app window is minimized or closed.
+- Provide data export to CSV or external services.
+- Add advanced analytics like streak tracking or productivity predictions.
+- Explore platform‑specific integrations such as calendar sync or system notifications.
+
+## Action Steps
+1. Monitor user feedback to prioritize enhancements.
+2. Prototype features behind flags before full release.
+3. Ensure cross‑platform compatibility for each new capability.
+
+## Challenges
+- Avoiding feature creep that complicates the core timer experience.
+- Balancing new features with maintenance and performance.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,17 @@
+# Visualization
+
+Linked with [AGENTS.md](../AGENTS.md), this document outlines how to present real‑time and historical timer data.
+
+## Objectives
+- Display current timer status with progress indicators.
+- Provide graphs and statistics for past sessions.
+
+## Action Steps
+1. Build a dashboard component that reflects live timer state.
+2. Render charts (e.g., line or bar graphs) of focus metrics and session history.
+3. Allow filtering by date ranges or session types.
+4. Ensure accessibility with readable colors and labels.
+
+## Challenges
+- Efficiently rendering graphs on resource‑constrained devices.
+- Designing a clean UI that works across screen sizes.


### PR DESCRIPTION
## Summary
- add framework comparison for Windows and cross-platform approaches
- document action plans for core timer, background execution, activity monitoring, visualization, and future enhancements
- index new docs within AGENTS.md for quick reference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80dbae6d48332bbe539865b4dc382