### PR TITLE
Add native app porting documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,20 @@
    - Combine event frequency with timer status to produce a "Focus Metric"
 
 4. **Visualization**
-   - Real-time status view with graphs and stats
-   - Persist and analyze historical data
+  - Real-time status view with graphs and stats
+  - Persist and analyze historical data
 
 5. **Future Enhancements**
-   - Ensure operation when browser minimized or closed
-   - Data export, advanced analytics, and platform-specific integrations
+  - Ensure operation when browser minimized or closed
+  - Data export, advanced analytics, and platform-specific integrations
+
+## Documentation Index
+
+- [Native App Porting Overview](docs/porting-overview.md)
+- [Windows Platform Plan](docs/windows-platform-plan.md)
+- [React Native Plan](docs/react-native-plan.md)
+- [Core Timer](docs/core-timer.md)
+- [Background Execution](docs/background-execution.md)
+- [Activity Monitoring and Focus Metric](docs/activity-monitoring.md)
+- [Visualization](docs/visualization.md)
+- [Future Enhancements](docs/future-enhancements.md)

--- a/docs/activity-monitoring.md
+++ b/docs/activity-monitoring.md
@@ -1,0 +1,22 @@
+# Activity Monitoring and Focus Metric
+
+This document details how to capture user activity to compute a Focus Metric.
+
+## Goals
+- Track keyboard and mouse interactions while the timer is running.
+- Derive a score indicating how focused the user was during a session.
+
+## Windows
+- Use global hooks via Win32 APIs to record input frequency.
+- Respect privacy by limiting data to counts and timestamps.
+
+## React Native
+- Utilize `react-native-keyevent` and touch events to gather activity data.
+- Store aggregate metrics rather than raw events.
+
+## Next Steps
+1. Define algorithm for Focus Metric calculation.
+2. Implement platform-specific input listeners.
+3. Visualize focus data alongside session history.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/background-execution.md
+++ b/docs/background-execution.md
@@ -1,0 +1,19 @@
+# Background Execution
+
+This document outlines strategies for keeping the timer active when the application is not in the foreground.
+
+## Windows
+- Use a Windows Background Task or tray application to maintain the timer.
+- Employ `DispatcherTimer` or `ThreadPoolTimer` for low-power timing.
+- Display toast notifications upon session completion.
+
+## React Native
+- Utilize `react-native-background-fetch` to wake the app periodically.
+- Combine with local notifications to alert users.
+
+## Next Steps
+1. Prototype background task on each platform.
+2. Verify battery and performance impact.
+3. Expose settings to enable/disable background behavior.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/core-timer.md
+++ b/docs/core-timer.md
@@ -1,0 +1,20 @@
+# Core Timer
+
+This document describes the shared timer logic needed by all native clients.
+
+## Features
+- Configurable work and break durations persisted locally.
+- Start, pause, resume, and reset operations.
+- Emits events when sessions start and complete.
+
+## Implementation Notes
+- Encapsulate logic in a platform-agnostic module (C# class library for Windows, JS module for React Native).
+- Provide hooks for UI components to subscribe to timer updates.
+- Expose serialization helpers for persisting state between app launches.
+
+## Next Steps
+1. Define timer state machine and interfaces.
+2. Write unit tests for state transitions.
+3. Integrate with platform-specific storage and notification systems.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/future-enhancements.md
+++ b/docs/future-enhancements.md
@@ -1,0 +1,20 @@
+# Future Enhancements
+
+This document captures ideas for extending the native applications beyond the initial release.
+
+## Potential Features
+- Sync session data to cloud storage providers.
+- Integrate with calendar apps to block focus time.
+- Provide widgets or complications for quick glance information.
+- Offer advanced analytics such as productivity trends.
+
+## Research Topics
+- Explore cross-device synchronization using SignalR or WebSockets.
+- Investigate platform-specific APIs for deep integrations (e.g., iOS Focus modes).
+
+## Next Steps
+1. Prioritize features based on user feedback.
+2. Prototype high-impact items.
+3. Plan incremental releases to deliver enhancements safely.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/porting-overview.md
+++ b/docs/porting-overview.md
@@ -1,0 +1,20 @@
+# Native App Porting Overview
+
+This document outlines the overall plan for porting the Simple Pomodoro Timer into native applications across platforms.
+
+## Objectives
+- Deliver a native experience on Windows and mobile platforms.
+- Reuse existing web code where possible while embracing platform capabilities.
+- Maintain feature parity with the existing web version.
+
+## Phased Roadmap
+1. **Foundation** – establish shared business logic and data storage mechanisms.
+2. **Platform Implementations** – build Windows (WPF/WinUI 3) and React Native clients.
+3. **Background Services** – ensure timers and notifications continue when the app is minimized.
+4. **Activity Monitoring** – capture user input to generate a Focus Metric.
+5. **Visualization and Analytics** – present real-time status and historical insights.
+6. **Enhancements** – extend with export, analytics, and platform integrations.
+
+For details on each area, consult the topic-specific documents.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/react-native-plan.md
+++ b/docs/react-native-plan.md
@@ -1,0 +1,22 @@
+# React Native Plan
+
+This document captures the approach for delivering a cross-platform client using React Native.
+
+## Technology
+- **Framework**: React Native with TypeScript for iOS, Android, and web.
+- **Packages**: `react-native-background-fetch` for periodic tasks and `expo-notifications` for alerts.
+- **State Management**: Reuse existing React hooks and context from the web app.
+
+## Background Execution
+- Configure background fetch to trigger timer checks at regular intervals.
+- Use platform-specific notification APIs to alert users when sessions end.
+
+## Data Storage
+- Store configuration and history using `AsyncStorage` or platform secure storage.
+
+## Next Steps
+1. Initialize Expo-managed workflow to simplify builds.
+2. Extract reusable timer logic into a shared JavaScript module.
+3. Implement notification handling and background fetch.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,22 @@
+# Visualization
+
+This document covers the user interface aspects for displaying timer status and historical data.
+
+## Real-Time Display
+- Show current session type, remaining time, and Focus Metric.
+- Provide controls for start, pause, and reset.
+
+## Historical Data
+- Present charts of past Pomodoro sessions and focus scores.
+- Allow filtering by date range and exporting to CSV.
+
+## Platform Considerations
+- Windows: leverage WinUI 3's `Chart` controls or community toolkits.
+- React Native: use libraries like `react-native-svg` and `victory-native`.
+
+## Next Steps
+1. Define data models for historical sessions.
+2. Prototype charts on each platform.
+3. Ensure accessibility and theme support.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/windows-platform-plan.md
+++ b/docs/windows-platform-plan.md
@@ -1,0 +1,22 @@
+# Windows Platform Plan
+
+This document summarizes key considerations for a Windows-first native port using WPF or WinUI 3.
+
+## Technology
+- **Framework**: WinUI 3 with .NET 8 for modern UI and long-term support.
+- **Packaging**: MSIX installer for easy distribution and automatic updates.
+- **Interop**: Access Win32 APIs for system tray integration and global input hooks.
+
+## Background Execution
+- Implement a background service to keep timers running when the window is minimized.
+- Provide system tray controls for quick start/stop and status display.
+
+## Data Storage
+- Store settings and session history in the user's AppData folder using `System.Text.Json`.
+
+## Next Steps
+1. Scaffold WinUI 3 project and establish MVVM structure.
+2. Port timer logic into a shared .NET class library.
+3. Implement tray icon and toast notifications.
+
+[Back to AGENTS](../AGENTS.md)


### PR DESCRIPTION
## Summary
- Document overall plan to port the Pomodoro timer into native applications
- Create detailed markdown docs for Windows, React Native, core timer, background execution, activity monitoring, visualization, and future enhancements
- Index all documentation from `AGENTS.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80dbae6d48332bbe539865b4dc382