### PR TITLE
docs: add native app porting plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,13 @@
 5. **Future Enhancements**
    - Ensure operation when browser minimized or closed
    - Data export, advanced analytics, and platform-specific integrations
+
+## Documentation Index
+
+- [Native Port Overview](docs/native-port-overview.md)
+- [Framework Selection](docs/framework-selection.md)
+- [Core Timer](docs/core-timer.md)
+- [Background Execution](docs/background-execution.md)
+- [Activity Monitoring](docs/activity-monitoring.md)
+- [Visualization](docs/visualization.md)
+- [Future Enhancements](docs/future-enhancements.md)

--- a/docs/activity-monitoring.md
+++ b/docs/activity-monitoring.md
@@ -1,0 +1,15 @@
+# Activity Monitoring
+
+Captures user input events to calculate a "Focus Metric" that reflects engagement during Pomodoro sessions.
+
+## Windows Implementation
+- Listen for global keyboard and mouse events using Windows hooks.
+- Count events per interval and correlate with timer state.
+- Store aggregated metrics locally for analysis.
+
+## React Native Implementation
+- Use `react-native-keyevent` and gesture responders to track input activity.
+- Combine event counts with session data to compute the focus metric.
+- Persist metrics with `AsyncStorage` or a lightweight database like SQLite.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/background-execution.md
+++ b/docs/background-execution.md
@@ -1,0 +1,15 @@
+# Background Execution
+
+Ensures the timer continues running and can notify users even when the app is not in focus.
+
+## Windows Implementation
+- Provide a tray icon with start/stop controls.
+- Optionally run as a background service using `IBackgroundTask`.
+- Employ global keyboard shortcuts for quick interaction.
+
+## React Native Implementation
+- Integrate `react-native-background-fetch` for periodic wake-ups.
+- Use headless JS tasks to handle timer updates when the app is closed.
+- Respect platform-specific limitations on background processing.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/core-timer.md
+++ b/docs/core-timer.md
@@ -1,0 +1,20 @@
+# Core Timer
+
+This module replicates and extends the web timer functionality within native frameworks.
+
+## Requirements
+- Configurable Pomodoro and break durations stored locally.
+- Timer states: running, paused, completed.
+- Notifications when sessions end.
+
+## Windows Implementation (WinUI 3)
+- Use `DispatcherTimer` for timing.
+- Persist settings with `ApplicationData.Current.LocalSettings`.
+- Trigger toast notifications using Windows Notifications API.
+
+## React Native Implementation
+- Utilize `react-native-background-timer` for reliable timing.
+- Store settings with `AsyncStorage`.
+- Use local notifications via `react-native-push-notification`.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/framework-selection.md
+++ b/docs/framework-selection.md
@@ -1,0 +1,19 @@
+# Framework Selection
+
+This document compares target frameworks for porting the Pomodoro timer into native environments.
+
+## Windows-First: WPF / WinUI 3 (.NET)
+- Tight integration with Windows APIs and desktop capabilities.
+- Supports background services and global input hooks.
+- Small distribution size.
+
+## Cross-Platform: React Native
+- Reuses JavaScript/TypeScript and React knowledge.
+- Targets iOS, Android, Web, and Desktop with shared code.
+- Community packages such as `react-native-background-fetch` support background work.
+
+## Decision
+- Develop a Windows desktop app first with WinUI 3 to validate native features.
+- Follow with a React Native implementation for broader platform coverage.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/future-enhancements.md
+++ b/docs/future-enhancements.md
@@ -1,0 +1,15 @@
+# Future Enhancements
+
+Ideas for extending the native Pomodoro timer after initial release.
+
+## Potential Features
+- Ensure operation when minimized or closed via robust background services.
+- Export session data to CSV or cloud services.
+- Provide advanced analytics and goal tracking.
+- Integrate with calendar apps for automatic scheduling.
+
+## Research Topics
+- Battery impact of background tasks on mobile devices.
+- Platform-specific accessibility guidelines.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/native-port-overview.md
+++ b/docs/native-port-overview.md
@@ -1,0 +1,26 @@
+# Native Port Overview
+
+This document outlines the overall approach for porting the web-based Pomodoro timer into native applications.
+
+## Goals
+- Provide a consistent user experience across Windows and mobile platforms.
+- Maintain small bundle sizes and leverage existing code where possible.
+
+## Strategy
+1. Evaluate platform frameworks. See [Framework Selection](framework-selection.md).
+2. Build feature modules incrementally:
+   - [Core Timer](core-timer.md)
+   - [Background Execution](background-execution.md)
+   - [Activity Monitoring](activity-monitoring.md)
+   - [Visualization](visualization.md)
+   - [Future Enhancements](future-enhancements.md)
+3. Reuse existing JavaScript logic where practical, especially in React Native.
+4. Establish a shared design system for consistent UI elements.
+
+## Milestones
+- Prototype Windows desktop app using WinUI 3.
+- Create React Native prototype targeting iOS and Android.
+- Align data models and local storage approaches across platforms.
+- Conduct user testing and iterate.
+
+[Back to AGENTS](../AGENTS.md)

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,18 @@
+# Visualization
+
+Provides real-time status and historical insights for completed Pomodoro sessions.
+
+## Requirements
+- Display current session progress.
+- Show charts for daily and weekly focus metrics.
+- Allow users to review past sessions.
+
+## Windows Implementation
+- Build dashboards using WinUI's `Chart` controls or third-party libraries.
+- Implement MVVM pattern for data binding and testability.
+
+## React Native Implementation
+- Use libraries like `react-native-svg` and `victory-native` for charts.
+- Maintain a shared data model to drive both mobile and web views.
+
+[Back to AGENTS](../AGENTS.md)


### PR DESCRIPTION
## Summary
- document strategy for porting web timer to native platforms
- add framework comparison and detailed plans for timer, background work, activity tracking, and visualization
- index all documentation from AGENTS.md

## Testing
- `node --check src/timer.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80dbae6d48332bbe539865b4dc382