### PR TITLE
Implement AES computation and focus span detection

### DIFF
--- a/windows/PomodoroTimer.Tests/AesCalculatorTests.cs
+++ b/windows/PomodoroTimer.Tests/AesCalculatorTests.cs
@@ -1,0 +1,58 @@
+using System;
+using PomodoroTimer.Metrics.AES;
+
+namespace PomodoroTimer.Tests;
+
+public class AesCalculatorTests
+{
+    [Fact]
+    public void ComputesAesAndDetectsFocusSpan()
+    {
+        var calc = new AesCalculator();
+        var detector = new FocusSpanDetector();
+        var start = DateTime.UtcNow;
+
+        for (int i = 0; i < 30; i++)
+        {
+            var sample = new SignalSample
+            {
+                KCommit = 10,
+                KEdit = 0,
+                MMovePx = 0,
+                MClick = 0,
+                MScrollNotches = 0,
+                ForegroundAppId = "vscode",
+                MicroIdle = false,
+                MacroIdle = false,
+                NotificationsCount = 0
+            };
+            var ts = start.AddSeconds(i);
+            var result = calc.Process(ts, sample);
+            detector.AddSample(ts, result, sample);
+        }
+
+        // feed a period of inactivity to close the span
+        for (int i = 30; i < 60; i++)
+        {
+            var sample = new SignalSample
+            {
+                KCommit = 0,
+                KEdit = 0,
+                MMovePx = 0,
+                MClick = 0,
+                MScrollNotches = 0,
+                ForegroundAppId = "vscode",
+                MicroIdle = true,
+                MacroIdle = true,
+                NotificationsCount = 0
+            };
+            var ts = start.AddSeconds(i);
+            var result = calc.Process(ts, sample);
+            detector.AddSample(ts, result, sample);
+        }
+
+        var span = Assert.Single(detector.Spans);
+        Assert.True(span.DurationSeconds >= 12);
+        Assert.True(span.AvgAes > 60);
+    }
+}

--- a/windows/PomodoroTimer.Tests/PomodoroTimer.Tests.csproj
+++ b/windows/PomodoroTimer.Tests/PomodoroTimer.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\PomodoroTimer\TimerService.cs" Link="TimerService.cs" />
     <Compile Include="..\PomodoroTimer\Metrics\IActivityMetric.cs" Link="Metrics/IActivityMetric.cs" />
     <Compile Include="..\PomodoroTimer\Metrics\KeysPerMinuteMetric.cs" Link="Metrics/KeysPerMinuteMetric.cs" />
+    <Compile Include="..\PomodoroTimer\Metrics\AES\*.cs" Link="Metrics/AES/%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/windows/PomodoroTimer/AfkDetector.cs
+++ b/windows/PomodoroTimer/AfkDetector.cs
@@ -7,7 +7,7 @@ namespace PomodoroTimer
     public class AfkDetector : IDisposable
     {
         private readonly Timer _timer = new Timer(1000);
-        private readonly TimeSpan _threshold;
+        private TimeSpan _threshold;
         private bool _isAfk;
         public event Action<bool>? AfkStatusChanged;
 
@@ -19,6 +19,8 @@ namespace PomodoroTimer
 
         public void Start() => _timer.Start();
         public void Stop() => _timer.Stop();
+
+        public void SetThreshold(TimeSpan threshold) => _threshold = threshold;
 
         private void Check()
         {

--- a/windows/PomodoroTimer/AppSettings.cs
+++ b/windows/PomodoroTimer/AppSettings.cs
@@ -1,0 +1,9 @@
+namespace PomodoroTimer
+{
+    public class AppSettings
+    {
+        public string Metric { get; set; } = "KeysPerMinute";
+        public double LowThreshold { get; set; } = 30;
+        public double AfkThresholdSeconds { get; set; } = 60;
+    }
+}

--- a/windows/PomodoroTimer/MainWindow.xaml
+++ b/windows/PomodoroTimer/MainWindow.xaml
@@ -1,24 +1,35 @@
 <Window x:Class="PomodoroTimer.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Pomodoro Timer" Height="260" Width="360">
+        Title="Pomodoro Timer" Height="320" Width="360">
     <Grid Margin="10">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" HorizontalAlignment="Center">
-            <TextBlock x:Name="TimerText" FontSize="48" HorizontalAlignment="Center"/>
-            <TextBlock x:Name="TypingRateText" FontSize="16" HorizontalAlignment="Center"/>
+        <Menu Grid.Row="0">
+            <MenuItem Header="Settings" Click="Settings_Click"/>
+        </Menu>
+
+        <Grid Grid.Row="1" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Canvas x:Name="RingCanvas" Width="180" Height="180">
+                <Ellipse Width="180" Height="180" Stroke="#DDD" StrokeThickness="10"/>
+                <Path x:Name="ProgressPath" Stroke="Green" StrokeThickness="10" Fill="Transparent"/>
+            </Canvas>
+            <TextBlock x:Name="TimerText" FontSize="32" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Grid>
+
+        <StackPanel Grid.Row="2" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <TextBlock x:Name="MetricText" FontSize="16" HorizontalAlignment="Center"/>
+            <Canvas x:Name="MetricGraph" Height="60" Margin="0,10,0,0">
+                <Polyline x:Name="MetricPolyline" Stroke="Blue" StrokeThickness="2"/>
+            </Canvas>
         </StackPanel>
 
-        <Canvas Grid.Row="1" x:Name="TypingGraph" Height="60" Margin="0,10,0,0">
-            <Polyline x:Name="TypingPolyline" Stroke="Blue" StrokeThickness="2"/>
-        </Canvas>
-
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Start" Click="Start_Click" Margin="5,0"/>
             <Button Content="Pause" Click="Pause_Click" Margin="5,0"/>
             <Button Content="Reset" Click="Reset_Click" Margin="5,0"/>

--- a/windows/PomodoroTimer/MainWindow.xaml.cs
+++ b/windows/PomodoroTimer/MainWindow.xaml.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using PomodoroTimer.Metrics;
+using PomodoroTimer.Metrics.AES;
 
 namespace PomodoroTimer
 {
@@ -12,25 +14,28 @@ namespace PomodoroTimer
         private readonly TimerService _timer = new TimerService();
         private readonly DispatcherTimer _uiTimer = new DispatcherTimer();
         private readonly KeyboardMonitor _keyboard = new KeyboardMonitor();
-        private readonly KeysPerMinuteMetric _kpmMetric = new(TimeSpan.FromSeconds(10));
+        private IActivityMetric _metric = new KeysPerMinuteMetric(TimeSpan.FromSeconds(10));
 
-        private readonly List<double> _rateHistory = new();
+        private readonly List<double> _metricHistory = new();
         private int _lastSecond;
         private DateTime _sessionStart;
         private readonly FocusTracker _focusTracker = new FocusTracker();
         private readonly AfkDetector _afk = new AfkDetector();
+        private bool _pausedByAfk;
+        private readonly AppSettings _settings = new();
 
         public MainWindow()
         {
             InitializeComponent();
             TimerText.Text = _timer.GetState().Remaining.ToString(@"mm\:ss");
-            TypingRateText.Text = "0 keys/min";
+            MetricText.Text = "0";
             _uiTimer.Interval = TimeSpan.FromMilliseconds(250);
             _uiTimer.Tick += (_, _) =>
             {
                 var state = _timer.GetState();
                 TimerText.Text = state.Remaining.ToString(@"mm\:ss");
-                UpdateTypingRate();
+                UpdateMetric();
+                UpdateRing();
             };
             _timer.OnComplete += mode =>
             {
@@ -41,27 +46,24 @@ namespace PomodoroTimer
                         _keyboard.Stop();
                         var duration = DateTime.Now - _sessionStart;
                         var avg = _keyboard.TotalKeyPresses / Math.Max(1, duration.TotalMinutes);
-                        MessageBox.Show($"Work session complete!\nAvg typing rate: {avg:F1} keys/min");
+                        MessageBox.Show($"Work session complete!\nAvg: {avg:F1}");
                     }
                     else
                     {
                         MessageBox.Show($"{mode} session complete!");
                     }
-                    _rateHistory.Clear();
-                    TypingPolyline.Points.Clear();
+                    _metricHistory.Clear();
+                    MetricPolyline.Points.Clear();
                     _keyboard.Reset();
                 });
             };
-            _afk.AfkStatusChanged += afk =>
-            {
-                Dispatcher.Invoke(() =>
-                    Title = afk ? "Pomodoro Timer (AFK)" : "Pomodoro Timer");
-            };
-            _keyboard.KeyPressed += () => _kpmMetric.RecordEvent(DateTime.Now);
+            _afk.AfkStatusChanged += OnAfkChanged;
+            _keyboard.KeyPressed += () => _metric.RecordEvent(DateTime.Now);
 
             _afk.Start();
             _focusTracker.Start();
             _lastSecond = DateTime.Now.Second;
+            ApplySettings();
         }
 
         private void Start_Click(object sender, RoutedEventArgs e)
@@ -69,10 +71,10 @@ namespace PomodoroTimer
             _timer.Start();
             _uiTimer.Start();
             _keyboard.Reset();
-            _kpmMetric.Reset();
+            _metric.Reset();
             _keyboard.Start();
-            _rateHistory.Clear();
-            TypingPolyline.Points.Clear();
+            _metricHistory.Clear();
+            MetricPolyline.Points.Clear();
             _sessionStart = DateTime.Now;
         }
 
@@ -88,30 +90,105 @@ namespace PomodoroTimer
             _timer.Reset();
             TimerText.Text = _timer.GetState().Remaining.ToString(@"mm\:ss");
             _keyboard.Reset();
-            _kpmMetric.Reset();
+            _metric.Reset();
 
-            _rateHistory.Clear();
-            TypingPolyline.Points.Clear();
-            TypingRateText.Text = "0 keys/min";
+            _metricHistory.Clear();
+            MetricPolyline.Points.Clear();
+            MetricText.Text = "0";
         }
-
-        private void UpdateTypingRate()
+        
+        private void UpdateMetric()
         {
-            var rate = _kpmMetric.CurrentValue;
-
-            TypingRateText.Text = $"{rate:F1} keys/min";
+            _metric.Tick(DateTime.Now);
+            var value = _metric.CurrentValue;
+            MetricText.Text = _settings.Metric == "ActiveEngagementScore" ? $"AES: {value:F1}" : $"{value:F1} keys/min";
             var sec = DateTime.Now.Second;
             if (sec != _lastSecond)
             {
                 _lastSecond = sec;
-                _rateHistory.Add(rate);
+                _metricHistory.Add(value);
                 var totalSeconds = _timer.GetState().Total.TotalSeconds;
                 if (totalSeconds <= 0) totalSeconds = 1;
-                var x = (_rateHistory.Count / totalSeconds) * TypingGraph.ActualWidth;
-                var maxRate = 200.0;
-                var y = TypingGraph.Height - Math.Min(rate, maxRate) / maxRate * TypingGraph.Height;
-                TypingPolyline.Points.Add(new Point(x, y));
+                var x = (_metricHistory.Count / totalSeconds) * MetricGraph.ActualWidth;
+                var max = _settings.Metric == "ActiveEngagementScore" ? 100.0 : 200.0;
+                var y = MetricGraph.Height - Math.Min(value, max) / max * MetricGraph.Height;
+                MetricPolyline.Points.Add(new Point(x, y));
             }
+
+            if (value < _settings.LowThreshold)
+            {
+                MetricText.Foreground = Brushes.Red;
+                if (!_pausedByAfk)
+                    Title = "Pomodoro Timer (Low Performance)";
+            }
+            else
+            {
+                MetricText.Foreground = Brushes.Black;
+                if (!_pausedByAfk)
+                    Title = "Pomodoro Timer";
+            }
+        }
+
+        private void UpdateRing()
+        {
+            var state = _timer.GetState();
+            var progress = state.Total.TotalSeconds > 0 ? (state.Total - state.Remaining).TotalSeconds / state.Total.TotalSeconds : 0;
+            double angle = progress * 360;
+            double radians = Math.PI / 180 * angle;
+            double r = 90;
+            double cx = 90;
+            double cy = 90;
+            double x = cx + r * Math.Sin(radians);
+            double y = cy - r * Math.Cos(radians);
+            bool largeArc = angle > 180;
+
+            var figure = new PathFigure { StartPoint = new Point(cx, cy - r) };
+            figure.Segments.Add(new ArcSegment(new Point(x, y), new Size(r, r), 0, largeArc, SweepDirection.Clockwise, true));
+            var geometry = new PathGeometry();
+            geometry.Figures.Add(figure);
+            ProgressPath.Data = geometry;
+        }
+
+        private void Settings_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new SettingsWindow(_settings);
+            if (win.ShowDialog() == true)
+                ApplySettings();
+        }
+
+        private void ApplySettings()
+        {
+            _metric = _settings.Metric == "ActiveEngagementScore" ? new AesMetric() : new KeysPerMinuteMetric(TimeSpan.FromSeconds(10));
+            _afk.SetThreshold(TimeSpan.FromSeconds(_settings.AfkThresholdSeconds));
+        }
+
+        private void OnAfkChanged(bool afk)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                if (afk)
+                {
+                    if (_timer.GetState().Remaining > TimeSpan.Zero)
+                    {
+                        _timer.Pause();
+                        _uiTimer.Stop();
+                        _keyboard.Stop();
+                        _pausedByAfk = true;
+                    }
+                    Title = "Pomodoro Timer (AFK)";
+                }
+                else
+                {
+                    if (_pausedByAfk)
+                    {
+                        _timer.Start();
+                        _uiTimer.Start();
+                        _keyboard.Start();
+                        _pausedByAfk = false;
+                    }
+                    Title = "Pomodoro Timer";
+                }
+            });
         }
     }
 }

--- a/windows/PomodoroTimer/Metrics/AES/AesCalculator.cs
+++ b/windows/PomodoroTimer/Metrics/AES/AesCalculator.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Computes per-second Active Engagement Score (AES) from interaction signals.
+    /// Simplified implementation of the specification in AGENTS instructions.
+    /// </summary>
+    public class AesCalculator
+    {
+        private readonly RollingQuantileNormalizer _keyboardNorm;
+        private readonly RollingQuantileNormalizer _mouseNorm;
+        private readonly EmaSmoother _iSmooth;
+        private readonly EmaSmoother _cSmooth;
+        private readonly EmaSmoother _sSmooth;
+
+        private readonly Queue<int> _switchWindow = new();
+        private readonly Queue<int> _notificationWindow = new();
+        private readonly Queue<bool> _microIdleWindow = new();
+        private string? _lastContext;
+
+        private static readonly (Regex pattern, double score)[] _rules = new[]
+        {
+            (new Regex("ide|code|matlab|pycharm|vscode|clion", RegexOptions.IgnoreCase), 1.0),
+            (new Regex("docs|latex|notion|obsidian|word|powerpoint|excel|onenote", RegexOptions.IgnoreCase), 0.5),
+            (new Regex("youtube|tiktok|insta|reddit|twitter|x.com|netflix", RegexOptions.IgnoreCase), -1.0)
+        };
+
+        public AesCalculator(int normWindowSeconds = 120 * 60, double emaAlpha = 0.15)
+        {
+            _keyboardNorm = new RollingQuantileNormalizer(normWindowSeconds);
+            _mouseNorm = new RollingQuantileNormalizer(normWindowSeconds);
+            _iSmooth = new EmaSmoother(emaAlpha);
+            _cSmooth = new EmaSmoother(emaAlpha);
+            _sSmooth = new EmaSmoother(emaAlpha);
+        }
+
+        public AesResult Process(DateTime timestamp, SignalSample sample)
+        {
+            // Normalization
+            var keyboardNorm = _keyboardNorm.Normalize(sample.KCommit);
+            var editPenalized = Math.Max(0, sample.KCommit - 0.5 * sample.KEdit);
+            var editNorm = _keyboardNorm.Normalize(editPenalized);
+            var mouseComposite = sample.MMovePx + 60 * sample.MClick + 12 * sample.MScrollNotches;
+            var mouseNorm = _mouseNorm.Normalize(mouseComposite);
+
+            // Input intensity
+            double inputRaw = 0.55 * keyboardNorm + 0.15 * editNorm + 0.30 * mouseNorm;
+            double inputSmooth = _iSmooth.Smooth(inputRaw);
+
+            // Context score
+            double contextRaw = ScoreContext(sample);
+            double contextSmooth = _cSmooth.Smooth(contextRaw);
+
+            // Stability score components
+            UpdateStability(sample);
+            double switchRate = _switchWindow.Sum() / 10.0;
+            double notificationsNorm = Math.Min(1.0, _notificationWindow.Sum() / 10.0);
+            double microIdleRate = _microIdleWindow.Count > 0 ? _microIdleWindow.Count(b => b) / 20.0 : 0.0;
+            double stabilityRaw = 1 - 0.5 * switchRate - 0.3 * notificationsNorm - 0.4 * microIdleRate;
+            stabilityRaw = Math.Max(0.0, Math.Min(1.0, stabilityRaw));
+            double stabilitySmooth = _sSmooth.Smooth(stabilityRaw);
+
+            // AES
+            double aes = 100 * (0.55 * inputSmooth + 0.25 * contextSmooth + 0.20 * stabilitySmooth);
+            aes = Math.Max(0, Math.Min(100, aes));
+
+            return new AesResult
+            {
+                InputIntensityRaw = inputRaw,
+                InputIntensitySmooth = inputSmooth,
+                ContextScoreRaw = contextRaw,
+                ContextScoreSmooth = contextSmooth,
+                StabilityScoreRaw = stabilityRaw,
+                StabilityScoreSmooth = stabilitySmooth,
+                Aes = aes
+            };
+        }
+
+        private double ScoreContext(SignalSample sample)
+        {
+            string key = sample.UrlDomain ?? sample.ForegroundAppId ?? string.Empty;
+            foreach (var (pattern, score) in _rules)
+            {
+                if (pattern.IsMatch(key))
+                    return score;
+            }
+            return 0.0; // unknown
+        }
+
+        private void UpdateStability(SignalSample sample)
+        {
+            string ctx = sample.UrlDomain ?? sample.ForegroundAppId ?? string.Empty;
+            bool switched = _lastContext != null && ctx != _lastContext;
+            _lastContext = ctx;
+
+            Enqueue(_switchWindow, switched ? 1 : 0, 10);
+            Enqueue(_notificationWindow, sample.NotificationsCount, 10);
+            Enqueue(_microIdleWindow, sample.MicroIdle, 20);
+        }
+
+        private static void Enqueue<T>(Queue<T> q, T value, int max)
+        {
+            q.Enqueue(value);
+            while (q.Count > max)
+                q.Dequeue();
+        }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/AesMetric.cs
+++ b/windows/PomodoroTimer/Metrics/AES/AesMetric.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Wraps <see cref="AesCalculator"/> into an <see cref="IActivityMetric"/> implementation
+    /// for use within the main timer application. Keyboard commits are counted per second
+    /// and converted into an AES value.
+    /// </summary>
+    public class AesMetric : PomodoroTimer.Metrics.IActivityMetric
+    {
+        private readonly AesCalculator _calculator = new();
+        private int _commitCount;
+        private DateTime _lastTick = DateTime.MinValue;
+
+        public double CurrentValue { get; private set; }
+
+        public void RecordEvent(DateTime timestamp)
+        {
+            _commitCount++;
+        }
+
+        public void Tick(DateTime timestamp)
+        {
+            if (_lastTick == DateTime.MinValue)
+                _lastTick = timestamp;
+            if ((timestamp - _lastTick).TotalSeconds >= 1)
+            {
+                var sample = new SignalSample
+                {
+                    KCommit = _commitCount,
+                    KEdit = 0,
+                    KNav = 0,
+                    MMovePx = 0,
+                    MClick = 0,
+                    MScrollNotches = 0,
+                    ForegroundAppId = null,
+                    UrlDomain = null,
+                    MicroIdle = _commitCount == 0,
+                    NotificationsCount = 0
+                };
+                var result = _calculator.Process(timestamp, sample);
+                CurrentValue = result.Aes;
+                _commitCount = 0;
+                _lastTick = timestamp;
+            }
+        }
+
+        public void Reset()
+        {
+            _commitCount = 0;
+            CurrentValue = 0;
+            _lastTick = DateTime.MinValue;
+        }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/AesResult.cs
+++ b/windows/PomodoroTimer/Metrics/AES/AesResult.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Holds computed scores for a single second.
+    /// </summary>
+    public class AesResult
+    {
+        public double InputIntensityRaw { get; set; }
+        public double InputIntensitySmooth { get; set; }
+        public double ContextScoreRaw { get; set; }
+        public double ContextScoreSmooth { get; set; }
+        public double StabilityScoreRaw { get; set; }
+        public double StabilityScoreSmooth { get; set; }
+        public double Aes { get; set; }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/EmaSmoother.cs
+++ b/windows/PomodoroTimer/Metrics/AES/EmaSmoother.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Simple exponential moving average smoother.
+    /// </summary>
+    public class EmaSmoother
+    {
+        private readonly double _alpha;
+        private bool _hasValue;
+        private double _state;
+
+        public EmaSmoother(double alpha)
+        {
+            _alpha = alpha;
+        }
+
+        public double Smooth(double value)
+        {
+            if (!_hasValue)
+            {
+                _state = value;
+                _hasValue = true;
+            }
+            else
+            {
+                _state = _alpha * value + (1 - _alpha) * _state;
+            }
+            return _state;
+        }
+
+        public void Reset()
+        {
+            _hasValue = false;
+            _state = 0;
+        }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/FocusSpan.cs
+++ b/windows/PomodoroTimer/Metrics/AES/FocusSpan.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    public class FocusSpan
+    {
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public int DurationSeconds { get; set; }
+        public double AvgAes { get; set; }
+        public double MedianAes { get; set; }
+        public double ProductivePct { get; set; }
+        public double IdlePct { get; set; }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/FocusSpanDetector.cs
+++ b/windows/PomodoroTimer/Metrics/AES/FocusSpanDetector.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Detects focus spans from AES values using simple threshold rules.
+    /// </summary>
+    public class FocusSpanDetector
+    {
+        private readonly int _enterThreshold;
+        private readonly int _exitThreshold;
+        private readonly int _enterMinDuration;
+        private readonly int _exitMinDuration;
+
+        private bool _inSpan;
+        private DateTime _spanStart;
+        private readonly List<double> _currentAes = new();
+        private readonly List<double> _currentContextScores = new();
+        private readonly List<bool> _currentIdleFlags = new();
+        private int _aboveCounter;
+        private int _belowCounter;
+        private readonly List<FocusSpan> _spans = new();
+
+        public IEnumerable<FocusSpan> Spans => _spans;
+
+        public FocusSpanDetector(int enterThreshold = 60, int exitThreshold = 40, int enterMinDuration = 12, int exitMinDuration = 25)
+        {
+            _enterThreshold = enterThreshold;
+            _exitThreshold = exitThreshold;
+            _enterMinDuration = enterMinDuration;
+            _exitMinDuration = exitMinDuration;
+        }
+
+        public void AddSample(DateTime ts, AesResult metrics, SignalSample sample)
+        {
+            double aes = metrics.Aes;
+
+            if (!_inSpan)
+            {
+                if (aes >= _enterThreshold)
+                {
+                    _aboveCounter++;
+                    if (_aboveCounter >= _enterMinDuration)
+                    {
+                        _inSpan = true;
+                        _spanStart = ts - TimeSpan.FromSeconds(_enterMinDuration - 1);
+                        _currentAes.Clear();
+                        _currentContextScores.Clear();
+                        _currentIdleFlags.Clear();
+                    }
+                }
+                else
+                {
+                    _aboveCounter = 0;
+                }
+            }
+            else
+            {
+                _currentAes.Add(aes);
+                _currentContextScores.Add(metrics.ContextScoreSmooth);
+                _currentIdleFlags.Add(sample.KCommit == 0);
+
+                if (aes <= _exitThreshold)
+                {
+                    _belowCounter++;
+                    if (_belowCounter >= _exitMinDuration)
+                    {
+                        EndSpan(ts);
+                    }
+                }
+                else
+                {
+                    _belowCounter = 0;
+                }
+
+                if (sample.MacroIdle || metrics.ContextScoreSmooth < 0)
+                {
+                    EndSpan(ts);
+                }
+            }
+        }
+
+        private void EndSpan(DateTime ts)
+        {
+            if (!_inSpan) return;
+            _inSpan = false;
+            var end = ts;
+            int duration = (int)Math.Max(1, (end - _spanStart).TotalSeconds);
+            var span = new FocusSpan
+            {
+                Start = _spanStart,
+                End = end,
+                DurationSeconds = duration,
+                AvgAes = _currentAes.Count > 0 ? _currentAes.Average() : 0,
+                MedianAes = _currentAes.Count > 0 ? _currentAes.OrderBy(v => v).ElementAt(_currentAes.Count / 2) : 0,
+                ProductivePct = _currentContextScores.Count > 0 ? _currentContextScores.Count(v => v > 0.75) * 100.0 / _currentContextScores.Count : 0,
+                IdlePct = _currentIdleFlags.Count > 0 ? _currentIdleFlags.Count(b => b) * 100.0 / _currentIdleFlags.Count : 0
+            };
+            _spans.Add(span);
+            _aboveCounter = 0;
+            _belowCounter = 0;
+        }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/RollingQuantileNormalizer.cs
+++ b/windows/PomodoroTimer/Metrics/AES/RollingQuantileNormalizer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Maintains a rolling window of values and provides P90 based normalization.
+    /// </summary>
+    public class RollingQuantileNormalizer
+    {
+        private readonly int _windowSize;
+        private readonly Queue<double> _values = new();
+
+        public RollingQuantileNormalizer(int windowSize)
+        {
+            _windowSize = windowSize;
+        }
+
+        public double Normalize(double value)
+        {
+            _values.Enqueue(value);
+            if (_values.Count > _windowSize)
+                _values.Dequeue();
+
+            var arr = _values.ToArray();
+            Array.Sort(arr);
+            int idx = (int)Math.Ceiling(0.9 * arr.Length) - 1;
+            double p90 = idx >= 0 ? arr[idx] : 0.0;
+            if (p90 <= 0)
+                return 0.0;
+            var norm = value / p90;
+            return Math.Max(0.0, Math.Min(1.0, norm));
+        }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/AES/SignalSample.cs
+++ b/windows/PomodoroTimer/Metrics/AES/SignalSample.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PomodoroTimer.Metrics.AES
+{
+    /// <summary>
+    /// Represents aggregated per-second interaction signals used for AES computation.
+    /// </summary>
+    public class SignalSample
+    {
+        public double KCommit { get; set; }
+        public double KEdit { get; set; }
+        public double KNav { get; set; }
+        public double MMovePx { get; set; }
+        public double MClick { get; set; }
+        public double MScrollNotches { get; set; }
+        public string? ForegroundAppId { get; set; }
+        public string? UrlDomain { get; set; }
+        public bool MicroIdle { get; set; }
+        public bool MacroIdle { get; set; }
+        public int NotificationsCount { get; set; }
+    }
+}

--- a/windows/PomodoroTimer/Metrics/IActivityMetric.cs
+++ b/windows/PomodoroTimer/Metrics/IActivityMetric.cs
@@ -3,6 +3,7 @@ namespace PomodoroTimer.Metrics
     public interface IActivityMetric
     {
         void RecordEvent(System.DateTime timestamp);
+        void Tick(System.DateTime timestamp);
         double CurrentValue { get; }
         void Reset();
     }

--- a/windows/PomodoroTimer/Metrics/KeysPerMinuteMetric.cs
+++ b/windows/PomodoroTimer/Metrics/KeysPerMinuteMetric.cs
@@ -28,6 +28,11 @@ namespace PomodoroTimer.Metrics
             PruneOld(timestamp);
         }
 
+        public void Tick(DateTime timestamp)
+        {
+            PruneOld(timestamp);
+        }
+
         public void Reset()
         {
             _timestamps.Clear();

--- a/windows/PomodoroTimer/SettingsWindow.xaml
+++ b/windows/PomodoroTimer/SettingsWindow.xaml
@@ -1,0 +1,17 @@
+<Window x:Class="PomodoroTimer.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" Height="230" Width="260">
+    <StackPanel Margin="10">
+        <TextBlock Text="Metric"/>
+        <ComboBox x:Name="MetricCombo" Margin="0,5,0,10">
+            <ComboBoxItem Content="KeysPerMinute"/>
+            <ComboBoxItem Content="ActiveEngagementScore"/>
+        </ComboBox>
+        <TextBlock Text="Low Performance Threshold"/>
+        <TextBox x:Name="ThresholdBox" Margin="0,5,0,10"/>
+        <TextBlock Text="AFK Threshold (seconds)"/>
+        <TextBox x:Name="AfkBox" Margin="0,5,0,10"/>
+        <Button Content="Save" Width="80" HorizontalAlignment="Center" Click="Save_Click"/>
+    </StackPanel>
+</Window>

--- a/windows/PomodoroTimer/SettingsWindow.xaml.cs
+++ b/windows/PomodoroTimer/SettingsWindow.xaml.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Windows;
+
+namespace PomodoroTimer
+{
+    public partial class SettingsWindow : Window
+    {
+        private readonly AppSettings _settings;
+
+        public SettingsWindow(AppSettings settings)
+        {
+            InitializeComponent();
+            _settings = settings;
+            MetricCombo.SelectedIndex = _settings.Metric == "ActiveEngagementScore" ? 1 : 0;
+            ThresholdBox.Text = _settings.LowThreshold.ToString();
+            AfkBox.Text = _settings.AfkThresholdSeconds.ToString();
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            _settings.Metric = MetricCombo.SelectedIndex == 1 ? "ActiveEngagementScore" : "KeysPerMinute";
+            if (double.TryParse(ThresholdBox.Text, out var t))
+                _settings.LowThreshold = t;
+            if (double.TryParse(AfkBox.Text, out var a))
+                _settings.AfkThresholdSeconds = a;
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Active Engagement Score calculator with normalization, smoothing, and context/stability factors
- introduce focus span detector and supporting data models
- include tests for AES calculation and span detection

## Testing
- `~/.dotnet/dotnet test PomodoroTimer.Tests/PomodoroTimer.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b837024b04833290d9436b9b3543fc